### PR TITLE
Disable versioning in local environments

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -100,7 +100,7 @@ class Builder
      */
     public function crossOrigin(string $keyword): string
     {
-        return "crossorigin=\"".$keyword."\"";
+        return 'crossorigin="'.$keyword.'"';
     }
 
     /**
@@ -135,7 +135,7 @@ class Builder
      */
     private static function parseExtension(string $path): string
     {
-        return preg_replace("#\?.*#", "", pathinfo($path, PATHINFO_EXTENSION));
+        return preg_replace("#\?.*#", '', pathinfo($path, PATHINFO_EXTENSION));
     }
 
 }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -33,7 +33,7 @@ class Builder
     private const SHA512 = 'sha512';
 
     /**
-     * Constructs a valid SRI string
+     * Constructs a valid SRI string based on the input file
      *
      * @param  string  $file
      *
@@ -89,7 +89,10 @@ class Builder
     }
 
     /**
-     * Constructs crossOrigin attribute
+     * Constructs crossOrigin attribute based on the keyword
+     * Valid HTML options
+     * anonymous | use-credentials | blank
+     *
      *
      * @param  string  $keyword
      *

--- a/src/ManifestBuilder.php
+++ b/src/ManifestBuilder.php
@@ -51,7 +51,6 @@ class ManifestBuilder
         $this->builder              = new Builder();
         $this->isMixManifestEnabled = config('vasri.mix-manifest');
         $this->mixManifestPath      = public_path('mix-manifest.json');
-        $this->mixManifest          = $this->manifestReader->getManifest($this->mixManifestPath);
     }
 
     /**
@@ -62,7 +61,7 @@ class ManifestBuilder
     {
         $vasriManifest = [];
         if ($this->isMixManifestEnabled && File::exists($this->mixManifestPath)) {
-            $manifest = $this->mixManifest;
+            $manifest = $this->manifestReader->getManifest($this->mixManifestPath);
             foreach ($manifest as $key => $val) {
                 $vasriManifest[] = $key;
             }

--- a/src/Vasri.php
+++ b/src/Vasri.php
@@ -97,22 +97,16 @@ class Vasri
      */
     private function addAttributes(string $file, bool $enableVersioning, bool $enableSRI, string $keyword): string
     {
-        try {
-            if ($enableVersioning && ($this->appEnvironment !== 'local' || config('vasri.local-versioning'))) {
-                $output = $this->getSourceAttribute($file, $this->getVersioning($file));
-            } elseif ($this->appEnvironment === 'local' && ! config('vasri.local-versioning')) {
-                $output = $this->getSourceAttribute($file);
-            } else {
-                $output = $this->getSourceAttribute($file);
-            }
-            if ($enableSRI) {
-                $output .= $this->getSRI($file, $keyword);
-            }
+        $output = $this->getSourceAttribute($file, $this->getVersioning($file));
 
-            return $output;
-        } catch (Exception $e) {
-            throw new Exception($e);
+        if ($this->appEnvironment === 'local' && ! config('vasri.local-versioning') || ! $enableVersioning) {
+            $output = $this->getSourceAttribute($file);
         }
+        if ($enableSRI) {
+            $output .= $this->getSRI($file, $keyword);
+        }
+
+        return $output;
     }
 
     private function getVersioning(string $file): string

--- a/src/Vasri.php
+++ b/src/Vasri.php
@@ -35,6 +35,11 @@ class Vasri
     private $vasriManifest;
 
     /**
+     * @var mixed
+     */
+    private $appEnvironment;
+
+    /**
      * Vasri constructor.
      */
     public function __construct()
@@ -42,6 +47,7 @@ class Vasri
         $this->builder        = new Builder();
         $this->manifestReader = new ManifestReader();
         $this->vasriManifest  = $this->manifestReader->getManifest(base_path('vasri-manifest.json'));
+        $this->appEnvironment = env('APP_ENV', 'production');
     }
 
     /**
@@ -96,7 +102,7 @@ class Vasri
     private function addAttribute(string $file, bool $enableVersioning)
     {
         try {
-            if ($enableVersioning === true) {
+            if ($enableVersioning === true && $this->appEnvironment !== 'local') {
                 $output = $this->builder->attribute($file)."=\"".$file.$this->vasriManifest[$file]['version']."\"";
             } else {
                 $output = $this->builder->attribute($file)."=\"".$file."\"";

--- a/src/config/vasri.php
+++ b/src/config/vasri.php
@@ -2,6 +2,7 @@
 
 return [
     'hash-algorithm' => 'sha384',
+    'local-versioning' => false,
     'mix-manifest'   => true,
     'assets' => [
         '/css/app.css',


### PR DESCRIPTION
Disable versioning in local environments with the ability to override by changing APP_ENV to anything other than local OR setting 'local-versioning' to true in the vasri config.